### PR TITLE
Default Chrome path or GOOGLE_CHROME_BIN

### DIFF
--- a/app.json
+++ b/app.json
@@ -9,8 +9,8 @@
   "environments": {
     "test": {
       "buildpacks": [
-        { "url": "https://github.com/heroku/heroku-buildpack-google-chrome" },
-        { "url": "https://github.com/joshwlewis/heroku-buildpack-chromedriver" },
+        { "url": "https://github.com/heroku/heroku-buildpack-google-chrome#export-shim" },
+        { "url": "https://github.com/heroku/heroku-buildpack-chromedriver" },
         { "url": "heroku/ruby" }
       ]
     }

--- a/config/initializers/browser.rb
+++ b/config/initializers/browser.rb
@@ -3,7 +3,7 @@ if Rails.env.test?
     caps = Selenium::WebDriver::Remote::Capabilities.chrome(
       'chromeOptions' => {
         'args' => ['headless', 'disable-gpu', 'no-sandbox'],
-        'binary' => ENV['GOOGLE_CHROME_BIN']
+        'binary' => ENV['GOOGLE_CHROME_SHIM']
       }.reject { |k, v| v.nil? }
     )
 

--- a/config/initializers/browser.rb
+++ b/config/initializers/browser.rb
@@ -1,40 +1,10 @@
 if Rails.env.test?
-  def find_chrome_bin
-    potential_binaries = [
-      'chromium-browser',
-      'chromium',
-      'google-chrome-canary',
-      'google-chrome-unstable',
-      'google-chrome-beta',
-      'google-chrome-stable',
-      'google-chrome'
-    ]
-
-    potential_paths = [
-      '/Applications/Chromium.app/Contents/MacOS/Chromium',
-      "#{ENV['HOME']}/Applications/Chromium.app/Contents/MacOS/Chromium",
-      '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary',
-      "#{ENV['HOME']}/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
-      '/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta',
-      "#{ENV['HOME']}/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta",
-    ]
-
-    potential_binaries.map do |bin|
-      path = `which #{bin}`.strip
-      Pathname.new(path).realpath.to_s if path.present?
-    end.concat(potential_paths.select do |path|
-      Pathname.new(path).realpath.to_s if File.exist?(path)
-    end).compact.first
-  end
-
   Capybara.register_driver :headless_chrome do |app|
-    path = ENV['CHROME_BIN'] || find_chrome_bin
-    puts "Using Google Chrome at #{path}"
     caps = Selenium::WebDriver::Remote::Capabilities.chrome(
       'chromeOptions' => {
         'args' => ['headless', 'disable-gpu', 'no-sandbox'],
-        'binary' => path
-      }
+        'binary' => ENV['GOOGLE_CHROME_BIN']
+      }.reject { |k, v| v.nil? }
     )
 
     Capybara::Selenium::Driver.new(


### PR DESCRIPTION
Remove chrome path finding logic in favour of the buildpack's `GOOGLE_CHROME_BIN` environment variable.