### PR TITLE
Upgrade to heroku-18, drop xvfb

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,11 +6,11 @@
   "scripts": {
     "test": "bin/rails test && bin/rails test:system"
   },
-  "stack": "cedar-14",
+  "stack": "heroku-18",
   "environments": {
     "test": {
       "buildpacks": [
-        { "url": "https://github.com/heroku/heroku-buildpack-xvfb-google-chrome" },
+        { "url": "https://github.com/heroku/heroku-buildpack-google-chrome" },
         { "url": "https://github.com/heroku/heroku-buildpack-chromedriver" },
         { "url": "heroku/ruby" }
       ]


### PR DESCRIPTION
`fill_in` via `capybara` and `chromedriver` used to fail without `xvfb`. This is no longer the case, and we can use headless chrome for testing. This allows us to move to `heroku-18` and drop the extra CI installation dependencies.